### PR TITLE
Split deployment workflow

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,5 +1,5 @@
 # ATTENTION: no deployment should be done until serverless.yml is properly setup
-name: deploy
+name: generate-docs
 on:
   push:
     branches:
@@ -14,7 +14,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -28,7 +28,16 @@ jobs:
       uses: serverless/github-action@master
       with:
         args: deploy --noDeploy
-    - name: serverless deploy
-      uses: serverless/github-action@master
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
       with:
-        args: --version
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: layer
+        template: docs/template.md

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,5 +1,6 @@
 [![Deploy status](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-layer/deploy?label=deploy&logo=Amazon%20AWS)](https://github.com/kaskadi/template-kaskadi-layer/actions?query=workflow%3Adeploy)
 [![Build status](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-layer/build?label=build&logo=serverless)](https://github.com/kaskadi/template-kaskadi-layer/actions?query=workflow%3Abuild)
+[![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-layer/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/template-kaskadi-layer/actions?query=workflow%3Agenerate-docs)
 
 <!-- You can add badges inside of this section if you'd like -->
 

--- a/docs/template.md
+++ b/docs/template.md
@@ -14,9 +14,11 @@ A `build` workflow (see [here](./.github/workflows/build.yml)) is running on `pu
 
 # Documentation
 
-This repository comes with a `generate-docs` job inside of the `deploy` workflow that generates documentation automatically for you by reading your main `serverless.yml` configuration file and extracting meta data of all layers you defined. See [here](https://github.com/kaskadi/action-generate-docs) for more information.
+This repository comes with a `generate-docs` workflow that generates documentation automatically for you by reading your main `serverless.yml` configuration file and extracting meta data of all layers you defined. See [here](https://github.com/kaskadi/action-generate-docs) and [there](./serverless.yml) for more information.
 
-If you would like to see the workflow configuration, head [here](./.github/workflows/deploy.yml).
+Before generating the documentation, the workflow will check for syntax error in your `serverless.yml` file.
+
+If you would like to see the workflow configuration, head [here](./.github/workflows/generate-docs.yml).
 
 You can configure the template used to generate the action documentation [here](./docs/template.md).
 


### PR DESCRIPTION
**Changes description**
Extracted `generate-docs` step from `deploy` workflow into a separate workflow. Both workflow checks for syntax error in `serverless.yml`. This was done to prevent deployment for failing in case the workflow couldn't generate the documentation automatically (we don't need an up to date documentation to deploy resources).

**New features**
- _`generate-docs` workflow:_ former `generate-docs` step of `deploy` workflow. Now also checks for syntax error in config file.

**Updated features**
- _`deploy` workflow:_ removed `generate-docs` step and fixed triggers.